### PR TITLE
Test update to stop rule err-elem-cit-gen-date-1-8 running on data availability section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "jms/serializer": "^1.4",
         "kevinrob/guzzle-cache-middleware": "^1.5",
         "elife/ping": "^1.0",
-        "elife/reference-schematron": "dev-master"
+        "elife/reference-schematron": "dev-data-accessiblity-bug"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "jms/serializer": "^1.4",
         "kevinrob/guzzle-cache-middleware": "^1.5",
         "elife/ping": "^1.0",
-        "elife/reference-schematron": "dev-data-accessiblity-bug"
+        "elife/reference-schematron": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9dda48f56350cdb096f168b89c4b8bf8",
+    "content-hash": "5a73fa72a5a35c496bd61f8a2da3b01d",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -766,16 +766,16 @@
         },
         {
             "name": "elife/reference-schematron",
-            "version": "dev-master",
+            "version": "dev-data-accessiblity-bug",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/reference-schematron.git",
-                "reference": "d772bb7717bd2e40a047b038fb4563aac8814537"
+                "reference": "fde0407c955dea1697f4a5d426bc0debe7030aa9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/reference-schematron/zipball/d772bb7717bd2e40a047b038fb4563aac8814537",
-                "reference": "d772bb7717bd2e40a047b038fb4563aac8814537",
+                "url": "https://api.github.com/repos/elifesciences/reference-schematron/zipball/fde0407c955dea1697f4a5d426bc0debe7030aa9",
+                "reference": "fde0407c955dea1697f4a5d426bc0debe7030aa9",
                 "shasum": ""
             },
             "type": "library",
@@ -783,10 +783,10 @@
                 "MIT"
             ],
             "support": {
-                "source": "https://github.com/elifesciences/reference-schematron/tree/master",
+                "source": "https://github.com/elifesciences/reference-schematron/tree/data-accessiblity-bug",
                 "issues": "https://github.com/elifesciences/reference-schematron/issues"
             },
-            "time": "2018-10-15T10:51:37+00:00"
+            "time": "2018-10-29T15:03:50+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a73fa72a5a35c496bd61f8a2da3b01d",
+    "content-hash": "9dda48f56350cdb096f168b89c4b8bf8",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -766,16 +766,16 @@
         },
         {
             "name": "elife/reference-schematron",
-            "version": "dev-data-accessiblity-bug",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/reference-schematron.git",
-                "reference": "fde0407c955dea1697f4a5d426bc0debe7030aa9"
+                "reference": "5877b7b9c25c809e435f126ecb8a01b3220441cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/reference-schematron/zipball/fde0407c955dea1697f4a5d426bc0debe7030aa9",
-                "reference": "fde0407c955dea1697f4a5d426bc0debe7030aa9",
+                "url": "https://api.github.com/repos/elifesciences/reference-schematron/zipball/5877b7b9c25c809e435f126ecb8a01b3220441cc",
+                "reference": "5877b7b9c25c809e435f126ecb8a01b3220441cc",
                 "shasum": ""
             },
             "type": "library",
@@ -783,10 +783,10 @@
                 "MIT"
             ],
             "support": {
-                "source": "https://github.com/elifesciences/reference-schematron/tree/data-accessiblity-bug",
+                "source": "https://github.com/elifesciences/reference-schematron/tree/master",
                 "issues": "https://github.com/elifesciences/reference-schematron/issues"
             },
-            "time": "2018-10-29T15:03:50+00:00"
+            "time": "2018-11-02T14:02:05+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
This tests the changes introduced in the following PR on `reference-schematron`: https://github.com/elifesciences/reference-schematron/pull/16